### PR TITLE
gcc support on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,15 @@ sudo: false
 node_js:
   - "7"
   - "6"
+env:
+  CXX=g++-5.2
 script:
   - npm run test-ci
 install:
   - npm install
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-5.2


### PR DESCRIPTION
Adds support for gcc on travis, this is necessary to build node-gyp dependencies