### PR TITLE
Forcing travis to perform tests using node 6.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 sudo: false
 node_js:
   - "7"
-  - "6"
+  - "6.9"
 env:
   CXX=g++-4.8
 script:


### PR DESCRIPTION
Forcing travis to run the tests using 6.9, so avoiding the latest version (v6.10.1) which crashes during the test