### PR TITLE
Extend output

### DIFF
--- a/src/Ext/Handlers/Web.js
+++ b/src/Ext/Handlers/Web.js
@@ -444,8 +444,8 @@ class Web extends Handler{
     writer.response = this.response;
 
     // adding context as part of the result
-    if ('context' in this.request.query && writer.options.extendRoot){
-      writer.options.extendRoot.context = this.request.query.context;
+    if ('context' in this.request.query && writer.options.extendOutput){
+      writer.options.extendOutput.context = this.request.query.context;
     }
 
     return writer;

--- a/src/Ext/Writers/WebResponse.js
+++ b/src/Ext/Writers/WebResponse.js
@@ -24,15 +24,16 @@ const _response = Symbol('response');
  *
  * Option Name | Description | Default Value
  * --- | --- | :---:
- * successStatus | success status code (error status code is driven by the \
- * status defined as a member of the exception) | `200`
  * header | plain object containing the header names (in camel case convention) \
  * that should be used by the response | `{}`
  * extendOutput | plain object that gets deep merged with the \
  * final output | `{}`
  * headerOnly | if enabled ends the response without any data | ::false::
- * resultLabel | custom label used to hold the result under data. In case of \
- * undefined (default) it uses a fallback label based on the value type: \
+ * successStatus | success status code (error status code is driven by the \
+ * status defined as a member of the exception) | `200`
+ * successResultLabel | custom label used by the success output to hold the result \
+ * under data. In case of undefined (default) it uses a fallback label based \
+ * on the value type: \
  * <br><br>- primitive values are held under 'value' \
  * <br>- array value is held under 'items' \
  * <br>- object is assigned with `null` \
@@ -72,13 +73,13 @@ class WebResponse extends Writer{
 
     // options
     Object.assign(this.options, {
-      successStatus: 200,
       headerOnly: false,
       header: {},
       extendOutput: {
         apiVersion: Settings.get('apiVersion'),
       },
-      resultLabel: undefined,
+      successStatus: 200,
+      successResultLabel: undefined,
     });
   }
 
@@ -256,7 +257,7 @@ class WebResponse extends Writer{
    * @private
    */
   _resultLabel(value){
-    let resultLabel = this.options.resultLabel;
+    let resultLabel = this.options.successResultLabel;
     if (resultLabel === undefined){
       if (TypeCheck.isPrimitive(value)){
         resultLabel = 'value';

--- a/src/Util/index.js
+++ b/src/Util/index.js
@@ -3,6 +3,7 @@ const debug = require('debug')('Oca');
 const assert = require('assert');
 const path = require('path');
 const crypto = require('crypto');
+const TypeCheck = require('js-typecheck');
 const promisify = require('es6-promisify');
 
 // promisifying
@@ -108,6 +109,36 @@ module.exports.mkdirs = async (fullPath, mode=0o777) => {
     }
   }
 };
+
+/**
+ * Merges two plain objects recursively and returns and returns a new one
+ *
+ * @param {Object} objectA - plain object a
+ * @param {Object} objectB - plain object b
+ * @return {Object}
+ */
+module.exports.deepMerge = (objectA, objectB) => {
+
+  assert(TypeCheck.isPlainObject(objectA), 'objectA needs to be a plain object');
+  assert(TypeCheck.isPlainObject(objectB), 'objectB needs to be a plain object');
+
+  const result = Object.assign({}, objectA);
+
+  for (const key in objectB){
+
+    // merging objects
+    if (TypeCheck.isPlainObject(objectB[key]) && key in objectA){
+      result[key] = module.exports.deepMerge(objectA[key], objectB[key]);
+    }
+    // overriding / assigning
+    else{
+      result[key] = objectB[key];
+    }
+  }
+
+  return result;
+};
+
 
 module.exports.ImmutableMap = require('./ImmutableMap');
 module.exports.LruCache = require('./LruCache');

--- a/test/Ext/Handlers/Web/writeOptions.js
+++ b/test/Ext/Handlers/Web/writeOptions.js
@@ -67,7 +67,7 @@ describe('Web Write Options:', () => {
       if (data.resultLabel){
         this.metadata.handler.web = {
           writeOptions: {
-            resultLabel: data.resultLabel,
+            successResultLabel: data.resultLabel,
           },
         };
       }

--- a/test/Ext/Handlers/Web/writeOptions.js
+++ b/test/Ext/Handlers/Web/writeOptions.js
@@ -88,9 +88,11 @@ describe('Web Write Options:', () => {
     _perform(data){
       this.metadata.handler.web = {
         writeOptions: {
-          extendData: {
-            test: 1,
-            test2: 2,
+          extendOutput: {
+            data: {
+              test: 1,
+              test2: 2,
+            },
           },
         },
       };
@@ -115,7 +117,7 @@ describe('Web Write Options:', () => {
     Oca.webfyAction(SuccessStatus, 'get', {restRoute: '/successStatus'});
     Oca.webfyAction(CustomHeader, 'get', {restRoute: '/customHeader'});
     Oca.webfyAction(ForceResultLabel, 'get', {restRoute: '/forceResultLabel'});
-    Oca.webfyAction(ExtendResult, 'get', {restRoute: '/extendResult'});
+    Oca.webfyAction(ExtendResult, 'get', {restRoute: '/extendOutput'});
 
     // express server
     app = express();
@@ -383,9 +385,9 @@ describe('Web Write Options:', () => {
     });
   });
 
-  it('Should test extendData option', (done) => {
+  it('Should test extendOutput option by extending the data', (done) => {
 
-    request(`http://localhost:${port}/extendResult`, (err, response, body) => {
+    request(`http://localhost:${port}/extendOutput`, (err, response, body) => {
 
       if (err){
         return done(err);

--- a/test/Util/deepMerge.js
+++ b/test/Util/deepMerge.js
@@ -1,0 +1,34 @@
+const assert = require('assert');
+const Oca = require('../../src');
+
+
+describe('Util deepMerge:', () => {
+  it('Should merge two plain objects', () => {
+
+    const objectA = {a: 1};
+    const objectB = {b: 10};
+    const result = Oca.Util.deepMerge(objectA, objectB);
+
+    assert.equal(objectA.a, result.a);
+    assert.equal(objectB.b, result.b);
+  });
+
+  it('Should merge two plain objects recursively', () => {
+
+    const objectA = {deep: {levelA: 1}};
+    const objectB = {deep: {levelB: 10}};
+    const result = Oca.Util.deepMerge(objectA, objectB);
+
+    assert.equal(objectA.deep.levelA, result.deep.levelA);
+    assert.equal(objectB.deep.levelB, result.deep.levelB);
+  });
+
+  it('Should merge two plain objects recursively where objectB overrides some of objectA', () => {
+
+    const objectA = {deep: {levelA: 1, otherLevel: 20}};
+    const objectB = {deep: {levelA: 10}};
+    const result = Oca.Util.deepMerge(objectA, objectB);
+    assert.equal(objectA.deep.levelA.otherLevel, result.deep.levelA.otherLevel);
+    assert.equal(objectB.deep.levelB, result.deep.levelB);
+  });
+});


### PR DESCRIPTION
- WebResponse: Added support for extendOutput option that allows custom arbitrary data to be injected to the final output
- Added deepMerge under Util, function used to merge recursively two plain objects