### PR TITLE
Enforcing primitive values

### DIFF
--- a/src/Ext/Inputs/BaseText.js
+++ b/src/Ext/Inputs/BaseText.js
@@ -10,6 +10,7 @@ const Input = require('../../Input');
  *
  * Property Name | Description | Defined&nbsp;by Default | Default Value
  * --- | --- | :---: | :---:
+ * primitive | ensures the value is a primitive | ::on:: | ::true::
  * regex | custom regular expression to test the value | ::off:: | ::none::
  *
  * All properties including the inherited ones can be listed via
@@ -42,7 +43,10 @@ class BaseText extends Input{
       if (!TypeCheck.isString(value)){
         throw new ValidationFail('Value needs to be a string', BaseText.errorCodes[0]);
       }
-
+      // primitive property
+      else if (this.property('primitive') && value instanceof String){
+        throw new ValidationFail('Value needs to be a primitive', BaseText.errorCodes[2]);
+      }
       // regex property
       else if (this.property('regex') && (!(new RegExp(this.property('regex'))).test(value))){
         throw new ValidationFail('Value does not meet the requirements', BaseText.errorCodes[1]);
@@ -55,10 +59,12 @@ class BaseText extends Input{
   static errorCodes = [
     '71b205ae-95ed-42a2-b5e9-ccf8e42ba454',
     'c902610c-ef17-4a10-bc75-887d1550793a',
+    '81b44982-3c7b-4a25-952b-70ec640c58d4',
   ];
 }
 
 // registering properties
+Input.registerProperty(BaseText, 'primitive', true);
 Input.registerProperty(BaseText, 'regex');
 
 module.exports = BaseText;

--- a/src/Ext/Inputs/Bool.js
+++ b/src/Ext/Inputs/Bool.js
@@ -20,6 +20,10 @@ const Input = require('../../Input');
  * *This input can also be created using the alias:* `boolean`
  *
  * <h2>Property Summary</h2>
+ * Property Name | Description | Defined&nbsp;by Default | Default Value
+ * --- | --- | :---: | :---:
+ * primitive | ensures the value is a primitive | ::on:: | ::true::
+ *
  * All properties including the inherited ones can be listed via
  * {@link registeredPropertyNames}
  */
@@ -39,8 +43,12 @@ class Bool extends Input{
     return super._validation(at).then((value) => {
 
       // type checking
-      if (!TypeCheck.isBool(value)){
+      if (!(TypeCheck.isBool(value) || value instanceof Boolean)){
         throw new ValidationFail('Value needs to be a boolean', Bool.errorCodes[0]);
+      }
+      // primitive property
+      else if (this.property('primitive') && value instanceof Boolean){
+        throw new ValidationFail('Value needs to be a primitive', Bool.errorCodes[1]);
       }
 
       return value;
@@ -74,6 +82,7 @@ class Bool extends Input{
 
   static errorCodes = [
     '4304c51a-a48f-41d2-a2b8-9ba43c6617f3',
+    '5decf593-f5a2-4368-a675-9b47256c395a',
   ];
 }
 
@@ -82,5 +91,8 @@ Input.registerInput(Bool);
 
 // also, registering as 'boolean' for convenience
 Input.registerInput(Bool, 'boolean');
+
+// registering properties
+Input.registerProperty(Bool, 'primitive', true);
 
 module.exports = Bool;

--- a/src/Ext/Inputs/Numeric.js
+++ b/src/Ext/Inputs/Numeric.js
@@ -18,6 +18,7 @@ const Input = require('../../Input');
  *
  * Property Name | Description | Defined&nbsp;by Default | Default Value
  * --- | --- | :---: | :---:
+ * primitive | ensures the value is a primitive | ::on:: | ::true::
  * min | minimum allowed value | ::off:: | ::none::
  * max | maximum allowed value | ::off:: | ::none::
  *
@@ -40,8 +41,12 @@ class Numeric extends Input{
     return super._validation(at).then((value) => {
 
       // type checking
-      if (!TypeCheck.isNumber(value)){
+      if (!(TypeCheck.isNumber(value) || value instanceof Number)){
         throw new ValidationFail('Value needs to be a number', Numeric.errorCodes[0]);
+      }
+      // primitive property
+      else if (this.property('primitive') && value instanceof Number){
+        throw new ValidationFail('Value needs to be a primitive', Numeric.errorCodes[3]);
       }
       // min property
       else if (this.hasProperty('min') && value < this.property('min')){
@@ -71,6 +76,7 @@ class Numeric extends Input{
     'b9f7f1bf-18a3-45f8-83d0-aa8f34f819f6',
     '12e85420-04ae-4ef0-b64c-400b68bced3c',
     'd1d3ffc2-67e9-4404-873c-199603ca7632',
+    '2e2e4535-f346-4829-9cd1-ced2b8969c9e',
   ];
 }
 
@@ -81,6 +87,7 @@ Input.registerInput(Numeric);
 Input.registerInput(Numeric, 'number');
 
 // registering properties
+Input.registerProperty(Numeric, 'primitive', true);
 Input.registerProperty(Numeric, 'min');
 Input.registerProperty(Numeric, 'max');
 

--- a/src/Input.js
+++ b/src/Input.js
@@ -497,9 +497,9 @@ class Input{
   /**
    * Sets the value of the input
    *
-   * @param {*} inputValue - value that should be set to the input
+   * @param {*} value - value that should be set to the input
    */
-  setValue(inputValue){
+  setValue(value){
 
     // checking if input is read-only
     if (this.readOnly()){
@@ -509,8 +509,8 @@ class Input{
     // Due the overhead that may occur on going through recursively and freezing
     // the whole hierarchy of the value, it freezes only value itself. In case
     // this is not enough consider in changing it to perform a deep-freeze instead
-    this._value = (!this.property('immutable') || TypeCheck.isNone(inputValue)) ||
-      inputValue instanceof Buffer ? inputValue : Object.freeze(inputValue);
+    this._value = (!this.property('immutable') || TypeCheck.isNone(value)) ||
+      value instanceof Buffer ? value : Object.freeze(value);
 
     // flushing the cache when a new value is set
     this.clearCache();

--- a/test/Ext/Inputs/BaseText.js
+++ b/test/Ext/Inputs/BaseText.js
@@ -1,0 +1,81 @@
+const assert = require('assert');
+const Oca = require('../../../src');
+
+const BaseText = Oca.Ext.Inputs.BaseText;
+
+
+describe('BaseText Input:', () => {
+
+  it('Input should start empty', () => {
+
+    const input = new BaseText('input');
+    assert.equal(input.value(), null);
+  });
+
+  it('String value should be valid', () => {
+
+    const input = new BaseText('input');
+    input.setValue('value');
+    return input.validate.bind(input)();
+  });
+
+  it('Number value should not be valid', (done) => {
+    const input = new BaseText('input');
+    input.setValue(1);
+    input.validate.bind(input)().then((value) => {
+      done(new Error('unexpected value'));
+    }).catch((err) => {
+      done();
+    });
+  });
+
+  it("An empty string assigned as value should be considered as empty when calling 'isEmpty'", () => {
+    const input = new BaseText('input');
+    input.setValue('');
+    assert(input.isEmpty());
+  });
+
+  it("When 'regex' property is set, it should validate date based on a regex pattern", () => {
+
+    const input = new BaseText('input', {regex: '[0-9]{2}/[0-9]{2}/[0-9]{4}'});
+    input.setValue('25/05/1984');
+    return input.validate.bind(input)();
+  });
+
+  it("When 'regex' property is set, it should not validate the input with a wrong date format based on a regex pattern", (done) => {
+
+    const input = new BaseText('input', {regex: '[0-9]{2}/[0-9]{2}/[0-9]{4}'});
+    input.setValue('AA/05/1984');
+    input.validate.bind(input)().then((value) => {
+      done(new Error('unexpected value'));
+    }).catch((err) => {
+      done(err.code === 'c902610c-ef17-4a10-bc75-887d1550793a' ? null : err);
+    });
+  });
+
+  it('Input should fail when validating a non-primitive value when primitive property is enabled (default)', (done) => {
+
+    const input = new BaseText('input');
+    const value = new String('text'); // eslint-disable-line no-new-wrappers
+    input.setValue(value);
+
+    input.validate.bind(input)().then(() => {
+      done(new Error('unexpected value'));
+    }).catch((err) => {
+      done(err.code === '81b44982-3c7b-4a25-952b-70ec640c58d4' ? null : err);
+    });
+  });
+
+  it(`Input should allow validating a non primitive value when primitive property is disabled`, (done) => {
+
+    const input = new BaseText('input', {primitive: false});
+    const value = new String('text'); // eslint-disable-line no-new-wrappers
+    input.setValue(value);
+
+    input.validate.bind(input)().then(() => {
+      done();
+    }).catch((err) => {
+      done(err);
+    });
+  });
+});

--- a/test/Ext/Inputs/Bool.js
+++ b/test/Ext/Inputs/Bool.js
@@ -102,4 +102,30 @@ describe('Bool Input:', () => {
       done(err);
     });
   });
+
+  it('Input should fail when validating a non-primitive value when primitive property is enabled (default)', (done) => {
+    const input = Input.create('input: bool');
+
+    const value = new Boolean(true); // eslint-disable-line no-new-wrappers
+    input.setValue(value);
+
+    input.validate.bind(input)().then(() => {
+      done(new Error('unexpected value'));
+    }).catch((err) => {
+      done(err.code === '5decf593-f5a2-4368-a675-9b47256c395a' ? null : err);
+    });
+  });
+
+  it(`Input should allow validating a non primitive value when primitive property is disabled`, (done) => {
+    const input = Input.create('input: bool', {primitive: false});
+
+    const value = new Boolean(true); // eslint-disable-line no-new-wrappers
+    input.setValue(value);
+
+    input.validate.bind(input)().then(() => {
+      done();
+    }).catch((err) => {
+      done(err);
+    });
+  });
 });

--- a/test/Ext/Inputs/Numeric.js
+++ b/test/Ext/Inputs/Numeric.js
@@ -52,4 +52,30 @@ describe('Numeric Input:', () => {
       done((err.code === 'd1d3ffc2-67e9-4404-873c-199603ca7632') ? null : err);
     });
   });
+
+  it('Input should fail when validating a non-primitive value when primitive property is enabled (default)', (done) => {
+    const input = Input.create('input: numeric');
+
+    const value = new Number(10); // eslint-disable-line no-new-wrappers
+    input.setValue(value);
+
+    input.validate.bind(input)().then(() => {
+      done(new Error('unexpected value'));
+    }).catch((err) => {
+      done(err.code === '2e2e4535-f346-4829-9cd1-ced2b8969c9e' ? null : err);
+    });
+  });
+
+  it(`Input should allow validating a non primitive value when primitive property is disabled`, (done) => {
+    const input = Input.create('input: numeric', {primitive: false});
+
+    const value = new Number(10); // eslint-disable-line no-new-wrappers
+    input.setValue(value);
+
+    input.validate.bind(input)().then(() => {
+      done();
+    }).catch((err) => {
+      done(err);
+    });
+  });
 });

--- a/test/Ext/Inputs/Text.js
+++ b/test/Ext/Inputs/Text.js
@@ -91,26 +91,4 @@ describe('Text Input:', () => {
       done((err.code === 'c7ff4423-2c27-4538-acd7-923dada7f4d3') ? null : err);
     });
   });
-
-  it("When 'regex' property is set, it should validate date based on a regex pattern", () => {
-    const input = Input.create('input: text', {regex: '[0-9]{2}/[0-9]{2}/[0-9]{4}'});
-    input.setValue('25/05/1984');
-    return input.validate.bind(input)();
-  });
-
-  it("When 'regex' property is set, it should not validate the input with a wrong date format based on a regex pattern", (done) => {
-    const input = Input.create('input: text', {regex: '[0-9]{2}/[0-9]{2}/[0-9]{4}'});
-    input.setValue('AA/05/1984');
-    input.validate.bind(input)().then((value) => {
-      done(new Error('unexpected value'));
-    }).catch((err) => {
-      done(err.code === 'c902610c-ef17-4a10-bc75-887d1550793a' ? null : err);
-    });
-  });
-
-  it("An empty string assigned as value should be considered as empty when calling 'isEmpty'", () => {
-    const input = Input.create('input: text', {required: true});
-    input.setValue('');
-    assert(input.isEmpty());
-  });
 });


### PR DESCRIPTION
Adds support for the validation driven by the property 'primitive' that ensures the value is primitive (enabled by default).

- BaseText Input: added primitive validation
- Numeric Input: added primitive validation
- Bool Input: added primitive validation